### PR TITLE
fix deprecation warning, resolves #3

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Set up message of the day (motd)
   company: Adria Galin
   license: GPLv3
-  min_ansible_version: 1.9
+  min_ansible_version: 2.5
   platforms:
     - name: EL
       versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,10 +23,10 @@
 
 - name: Add motd tail
   template: src=etc/motd.j2 dest=/etc/motd.tail
-  when: motd_tail_supported|success
+  when: motd_tail_supported is success
   tags: [ 'motd', 'common' ]
 
 - name: Add motd
   template: src=etc/motd.j2 dest=/etc/motd
-  when: motd_tail_supported|failed
+  when: motd_tail_supported is failed
   tags: [ 'motd', 'common' ]


### PR DESCRIPTION
Syntax change because Ansible-provided jinja tests as filters will be removed in Ansible 2.9