### PR TITLE
fix a deprecation warning in `result|failed` and makes iteritems() compatible with Python2 and Python3

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,21 +13,6 @@ ag_motd_info:
   - " CPUs:    ": "{{ ansible_processor_vcpus }}"
   - " RAM:     ": "{{ (ansible_memtotal_mb / 1000) | round(1) }}GB"
 
----
-# defaults file for adriagalin.motd
-
-ag_motd_add_footer: false
-
-ag_motd_sysadmins_signature: Random system administrators
-ag_motd_sysadmins_email: random@random.com
-
-ag_motd_info:
-  - " FQDN:    ": "{{ ansible_fqdn }}"
-  - " Distro:  ": "{{ ansible_distribution }} {{ ansible_distribution_version }} {{ ansible_distribution_release }}"
-  - " Virtual: ": "{{ 'YES' if ansible_virtualization_role == 'guest' else 'NO' }}\n"
-  - " CPUs:    ": "{{ ansible_processor_vcpus }}"
-  - " RAM:     ": "{{ (ansible_memtotal_mb / 1000) | round(1) }}GB"
-
 ag_motd_content: |
 
   --------------------------------------------------------------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,21 @@ ag_motd_info:
   - " CPUs:    ": "{{ ansible_processor_vcpus }}"
   - " RAM:     ": "{{ (ansible_memtotal_mb / 1000) | round(1) }}GB"
 
+---
+# defaults file for adriagalin.motd
+
+ag_motd_add_footer: false
+
+ag_motd_sysadmins_signature: Random system administrators
+ag_motd_sysadmins_email: random@random.com
+
+ag_motd_info:
+  - " FQDN:    ": "{{ ansible_fqdn }}"
+  - " Distro:  ": "{{ ansible_distribution }} {{ ansible_distribution_version }} {{ ansible_distribution_release }}"
+  - " Virtual: ": "{{ 'YES' if ansible_virtualization_role == 'guest' else 'NO' }}\n"
+  - " CPUs:    ": "{{ ansible_processor_vcpus }}"
+  - " RAM:     ": "{{ (ansible_memtotal_mb / 1000) | round(1) }}GB"
+
 ag_motd_content: |
 
   --------------------------------------------------------------------------
@@ -26,7 +41,7 @@ ag_motd_content: |
   please contact with your system administrators.
 
   {% for item in ag_motd_info %}
-  {% for key, value in item.iteritems() %}
+  {% for key, value in item.items() | list %}
   {{ key }}{{ value }}
   {% endfor %}
   {% endfor %}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,17 +1,26 @@
 ---
 # tasks file for adriagalin.motd
 - name: Add 99-footer file
-  copy: src=99-footer dest=/etc/update-motd.d/99-footer owner=root group=root mode=0755
+  copy:
+    src: 99-footer
+    dest: /etc/update-motd.d/99-footer
+    owner: root
+    group: root
+    mode: 0755
   when: ag_motd_add_footer
   tags: [ 'motd', 'common' ]
 
 - name: Delete 99-footer file
-  file: path=/etc/update-motd.d/99-footer state=absent
+  file:
+    path: /etc/update-motd.d/99-footer
+    state: absent
   when: not ag_motd_add_footer
   tags: [ 'motd', 'common' ]
 
 - name: Delete /etc/motd file
-  file: path=/etc/motd state=absent
+  file:
+    path: /etc/motd
+    state: absent
   when: ag_motd_add_footer
   tags: [ 'motd', 'common' ]
 
@@ -22,11 +31,15 @@
   tags: [ 'motd', 'common' ]
 
 - name: Add motd tail
-  template: src=etc/motd.j2 dest=/etc/motd.tail
-  when: motd_tail_supported|success
+  template:
+    src: etc/motd.j2
+    dest: /etc/motd.tail
+  when: motd_tail_supported is success
   tags: [ 'motd', 'common' ]
 
 - name: Add motd
-  template: src=etc/motd.j2 dest=/etc/motd
-  when: motd_tail_supported|failed
+  template:
+    src: etc/motd.j2
+    dest: /etc/motd
+  when: motd_tail_supported is failed
   tags: [ 'motd', 'common' ]


### PR DESCRIPTION
This PR will fix a deprecation warning in `result|failed`, makes iteritems() compatible with Python2 and Python3 (closing issue #5)  and change the main.yml format.

[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using `result|failed` use `result is failed`. This feature will be removed in version 2.9. Deprecation warnings can be disabled by setting deprecation_warnings=False

fatal: [host1]: FAILED! => {\"changed\": false, \"msg\": \"AnsibleUndefinedVariable: 'dict object' has no attribute 'iteritems'\"}