### PR TITLE
Fixing idempotency and deprecation warnings.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,21 +7,21 @@
     owner: root
     group: root
     mode: 0755
-  when: ag_motd_add_footer
+  when: ag_motd_add_footer | bool
   tags: [ 'motd', 'common' ]
 
 - name: Delete 99-footer file
   file:
     path: /etc/update-motd.d/99-footer
     state: absent
-  when: not ag_motd_add_footer
+  when: not ag_motd_add_footer | bool
   tags: [ 'motd', 'common' ]
 
 - name: Delete /etc/motd file
   file:
     path: /etc/motd
     state: absent
-  when: ag_motd_add_footer
+  when: ag_motd_add_footer | bool
   tags: [ 'motd', 'common' ]
 
 - name: Check motd tail supported

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,5 +41,5 @@
   template:
     src: etc/motd.j2
     dest: /etc/motd
-  when: motd_tail_supported is failed
+  when: motd_tail_supported.stat.exists | bool == false
   tags: [ 'motd', 'common' ]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,5 +41,5 @@
   template:
     src: etc/motd.j2
     dest: /etc/motd
-  when: motd_tail_supported.stat.exists | bool == false
+  when: not motd_tail_supported.stat.exists | bool
   tags: [ 'motd', 'common' ]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,8 +25,8 @@
   tags: [ 'motd', 'common' ]
 
 - name: Check motd tail supported
-  shell: test -f /etc/update-motd.d/99-footer
-  ignore_errors: True
+  stat:
+    path: /etc/update-motd.d/99-footer
   register: motd_tail_supported
   tags: [ 'motd', 'common' ]
 
@@ -34,7 +34,7 @@
   template:
     src: etc/motd.j2
     dest: /etc/motd.tail
-  when: motd_tail_supported is success
+  when: motd_tail_supported.stat.exists | bool
   tags: [ 'motd', 'common' ]
 
 - name: Add motd


### PR DESCRIPTION
This change fixes the idempotency of the role. The issue is specifically in the usage of shell module in:

```yaml
- name: Check motd tail supported
  shell: test -f /etc/update-motd.d/99-footer
  ignore_errors: True
  register: motd_tail_supported
  tags: [ 'motd', 'common' ]
```
This produces a "changed" status always no matter if the role changes something or not breaking the idempotence. Using stat fixes this issue and also is always recommended to use native Ansible modules instead of calling shell commands through command/shell ones.

As well, I've added the bool filter in the evalutation of the variable ag_motd_add_footer. This way we supress an ugly deprecation message when running it.