### PR TITLE
Fix role name in example playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Example Playbook
 ```yaml
     - hosts: servers
       roles:
-         - { role: adriagalin.motd }
+         - { role: ansible.motd }
 ```
 
 This playbook produces the /etc/motd file looking like this:


### PR DESCRIPTION
The example playbook in the README produces an error:
```
ERROR! the role 'adriagalin.motd' was not found in ansible.legacy:/Users/jerred/git/ansible-playbook/roles:/Users/jerred/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:/Users/jerred/git/ansible-playbook/roles:/Users/jerred/git/ansible-playbook

The error appears to be in '/Users/jerred/git/ansible-playbook/roles/server/meta/main.yml': line 10, column 5, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

    become: yes
  - role: adriagalin.motd
    ^ here
```

The role name should actually be "ansible.motd". Changing it results in the playbook running successfully.